### PR TITLE
fixed footer, fixed 404 vertical aligment

### DIFF
--- a/src/assets/styles.scss
+++ b/src/assets/styles.scss
@@ -189,16 +189,3 @@ app-root {
 router-outlet ~ app-footer {
   margin-top: auto;
 }
-app-not-found {
-  display: flex;
-  flex-direction: column;
-  flex: 1; 
-}
-
-
-app-not-found app-section-wrapper {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  justify-content: center;
-}


### PR DESCRIPTION
This pull request fixes the issue where the footer would float midway up the screen on the 404 page when the content is short.

Changes:
- Makes the <app-not-found> component expand to fill the remaining space
- Vertically centers the 404 message
- Ensures the footer remains pinned to the bottom as expected
- Ensures it only affects 404 component and does not break any other pages