### PR TITLE
refactor: move inline CSS styles to separate SCSS file (#22)

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -20,47 +20,42 @@
             "outputPath": "dist/spiderly-website",
             "index": "src/index.html",
             "browser": "src/main.ts",
-            "polyfills": ["zone.js"],
+            "polyfills": [
+              "zone.js"
+            ],
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
             "assets": [
-              {
-                "glob": "**/*",
-                "input": "public"
-              }
+              "src/favicon.ico",
+              "src/assets"
             ],
-            "styles": ["src/assets/styles.scss"],
-            "scripts": [],
-            "server": "src/main.server.ts",
-            "outputMode": "static",
-            "prerender": true,
-            "ssr": false
+            "styles": [
+              "node_modules/primeng/resources/themes/lara-light-blue/theme.css",
+              "node_modules/primeng/resources/primeng.min.css",
+              "node_modules/primeicons/primeicons.css",
+              "src/assets/styles.scss",
+              "src/styles.scss"
+            ],
+            "scripts": []
           },
           "configurations": {
             "production": {
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kB",
-                  "maximumError": "3MB"
+                  "maximumWarning": "500kb",
+                  "maximumError": "1mb"
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "4kB",
-                  "maximumError": "8kB"
+                  "maximumWarning": "2kb",
+                  "maximumError": "4kb"
                 }
               ],
               "outputHashing": "all"
             },
             "development": {
-              "optimization": {
-                "scripts": false,
-                "styles": {
-                  "minify": true,
-                  "inlineCritical": true
-                },
-                "fonts": true
-              },
+              "optimization": false,
               "extractLicenses": false,
               "sourceMap": true
             }
@@ -77,27 +72,34 @@
               "buildTarget": "spiderly-website:build:development"
             }
           },
-          "defaultConfiguration": "development",
-          "options": {
-            "hmr": true
-          }
+          "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n"
+          "builder": "@angular-devkit/build-angular:extract-i18n",
+          "options": {
+            "buildTarget": "spiderly-website:build"
+          }
         },
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
-            "polyfills": ["zone.js", "zone.js/testing"],
+            "polyfills": [
+              "zone.js",
+              "zone.js/testing"
+            ],
             "tsConfig": "tsconfig.spec.json",
             "inlineStyleLanguage": "scss",
             "assets": [
-              {
-                "glob": "**/*",
-                "input": "public"
-              }
+              "src/favicon.ico",
+              "src/assets"
             ],
-            "styles": ["src/assets/styles.scss"],
+            "styles": [
+              "node_modules/primeng/resources/themes/lara-light-blue/theme.css",
+              "node_modules/primeng/resources/primeng.min.css",
+              "node_modules/primeicons/primeicons.css",
+              "src/assets/styles.scss",
+              "src/styles.scss"
+            ],
             "scripts": []
           }
         }

--- a/src/app/components/homepage/get-started/get-started.component.html
+++ b/src/app/components/homepage/get-started/get-started.component.html
@@ -6,7 +6,7 @@
       </div>
     </h2>
   </div>
-  <div style="display: flex; gap: 18px; flex-direction: column;">
+  <div class="flex flex-column gap-lg">
     @for (step of getStartedSteps; track $index; let index = $index) {
       <div class="carousel-item-wrapper">
         <div class="get-started-card">
@@ -16,15 +16,15 @@
           <div [innerHTML]="step.description">
           </div>
         </div>
-        <div *ngIf="step.terminalMessages != null" style="width: 100%; height: fit-content;">
+        <div *ngIf="step.terminalMessages != null" class="w-100">
           <div class="terminal-wrapper">
-            <div style="margin-bottom: 1rem; display: flex;">
+            <div class="flex mb-md">
               <div class="terminal-circle" style="background-color: var(--p-primary-color);"></div>
-              <div class="terminal-circle" style="background-color: #FBBF24; margin-left: 1rem;"></div>
-              <div class="terminal-circle" style="background-color: var(--p-secondary-color); margin-left: 1rem;"></div>
+              <div class="terminal-circle ml-sm" style="background-color: #FBBF24;"></div>
+              <div class="terminal-circle ml-sm" style="background-color: var(--p-secondary-color);"></div>
             </div>
             @for (terminalMessage of step.terminalMessages; track $index) {
-              <code style="margin-top: 1rem; display: flex; align-items: center;">
+              <code class="flex flex-align-center mt-sm">
                 <span class="terminal-message">
                   <div>
                     <span style="color: var(--p-primary-400);">$</span>

--- a/src/app/components/playground/class-code-editor/class-code-editor.component.html
+++ b/src/app/components/playground/class-code-editor/class-code-editor.component.html
@@ -1,4 +1,4 @@
-<code style="height: 100%;">
+<code class="h-100">
   @for (attributeFormGroup of baseFormService.getFormArrayGroups(entityFormGroup.controls.attributes); track $index; let entityAttributeIndex = $index) {
     <div>
       [<span class="punct">{{attributeFormGroup.controls.name.value}}</span>
@@ -10,9 +10,9 @@
     <span class="kw">public class</span> <span class="punct"> {{entityFormGroup.controls.name.value}}</span> {{ocb}}
   </div>
 
-  <div style="margin-bottom: 20px;"></div>
+  <div class="mb-lg"></div>
 
-  <div style="margin-left: 20px;">
+  <div class="ml-md">
     @for (propertyFormGroup of baseFormService.getFormArrayGroups(entityFormGroup.controls.properties); track $index; let propertyIndex = $index) {
       @for (attributeFormGroup of baseFormService.getFormArrayGroups(propertyFormGroup.controls.attributes); track $index; let propertyAttributeIndex = $index) {
         <div>
@@ -25,10 +25,9 @@
         <span class="kw">public {{propertyFormGroup.controls.dataType.value}}</span> {{propertyFormGroup.controls.name.value}} {{ocb}} <span class="kw">get</span>; <span class="kw">set</span>; {{ccb}} 
       </div>
 
-      <div style="margin-bottom: 20px;"></div>
+      <div class="mb-lg"></div>
     }
   </div>
 
   {{ccb}}
-  
 </code>

--- a/src/app/components/playground/web-app/entity-details/controls/spiderly-autocomplete/spiderly-autocomplete.component.html
+++ b/src/app/components/playground/web-app/entity-details/controls/spiderly-autocomplete/spiderly-autocomplete.component.html
@@ -1,4 +1,4 @@
-<div style="display: flex; flex-direction: column; gap: 0.5rem;">
+<div class="flex flex-column gap-sm">
   <div *ngIf="getTranslatedLabel() != '' && getTranslatedLabel() != null">
     <label>{{getTranslatedLabel()}}</label>
     <required *ngIf="control?.required"></required>
@@ -27,8 +27,8 @@
     [emptyMessage]="emptyMessage"
     [lazy]="true"
     />
-    <span *ngIf="showAddon" (click)="addonClick()" class="p-inputgroup-addon" style="cursor: pointer; background-color: var(--primary-color); border-color: var(--primary-color);">
-      <i class="{{addonIcon}}" style="color: #fff;"></i>
+    <span *ngIf="showAddon" (click)="addonClick()" class="p-inputgroup-addon primary">
+      <i class="{{addonIcon}}"></i>
     </span>
   </div>
 </div>

--- a/src/app/components/playground/web-app/entity-details/controls/spiderly-file/spiderly-file.component.ts
+++ b/src/app/components/playground/web-app/entity-details/controls/spiderly-file/spiderly-file.component.ts
@@ -12,17 +12,7 @@ import { ButtonModule } from 'primeng/button';
 @Component({
     selector: 'spiderly-file',
     templateUrl: './spiderly-file.component.html',
-    styles: [
-      `
-      :host {
-        ::ng-deep {
-            .p-fileupload-header{
-              padding: 12px 18px !important;
-            }
-          }
-        }
-      `
-    ],
+    styles: [],
     styleUrl: '../../../../../../pages/playground/playground.component.scss',
     standalone: true,
     imports: [

--- a/src/app/components/playground/web-app/entity-details/controls/spiderly-multiautocomplete/spiderly-multiautocomplete.component.html
+++ b/src/app/components/playground/web-app/entity-details/controls/spiderly-multiautocomplete/spiderly-multiautocomplete.component.html
@@ -1,4 +1,4 @@
-<div style="display: flex; flex-direction: column; gap: 0.5rem;">
+<div class="flex flex-column gap-sm">
   <div>
     <label>{{getTranslatedLabel()}}</label>
     <required *ngIf="control?.required"></required>
@@ -22,8 +22,8 @@
       [style]="{'width':'100%'}"
       [inputStyle]="{'width':'100%'}"
       />
-    <span *ngIf="showAddon" (click)="addonClick()" class="p-inputgroup-addon" style="cursor: pointer; background-color: var(--primary-color); border-color: var(--primary-color);">
-      <i class="pi {{addonIcon}}" style="color: #fff;"></i>
+    <span *ngIf="showAddon" (click)="addonClick()" class="p-inputgroup-addon primary">
+      <i class="pi {{addonIcon}}"></i>
     </span>
   </div>
 </div>

--- a/src/app/components/playground/web-app/entity-details/controls/spiderly-password/spiderly-password.component.html
+++ b/src/app/components/playground/web-app/entity-details/controls/spiderly-password/spiderly-password.component.html
@@ -1,4 +1,4 @@
-<div style="display: flex; flex-direction: column; gap: 0.5rem;">
+<div class="flex flex-column gap-sm">
   <div>
     <label>{{getTranslatedLabel()}}</label>
     <required *ngIf="control?.required"></required>

--- a/src/app/components/playground/web-app/entity-details/required/required.component.html
+++ b/src/app/components/playground/web-app/entity-details/required/required.component.html
@@ -1,1 +1,1 @@
-<span style="color: red; margin-left: 4px;">*</span>
+<span class="text-red ml-4px">*</span>

--- a/src/app/components/playground/web-app/entity-details/spiderly-panels/panel-header/panel-header.component.html
+++ b/src/app/components/playground/web-app/entity-details/spiderly-panels/panel-header/panel-header.component.html
@@ -1,6 +1,6 @@
 <div>
     @if (tabs == null) {
-        <div style="display: flex; align-items: center; gap: 14px; flex-wrap: wrap;">
+        <div class="flex flex-align-center gap-md flex-wrap">
             <span *ngIf="index != null" class="number-circle">{{index + 1}}</span>
             <i *ngIf="icon != null" class="{{icon}} primary-color" [style]="showBigTitle ? 'font-size: 19px' : 'font-size: 16px;'"></i> 
             <div *ngIf="title != null && title != ''" [style]="(showBigTitle ? 'font-size: 16px;' : '')">{{title}}</div>
@@ -9,13 +9,8 @@
     @else {
         @for (tab of tabs; track $index) {
             <div (click)="setTabIsSelected(tab)"
-                [style]="{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '14px',
-                    cursor: 'pointer',
-                    fontWeight: tab.isSelected ? '700' : 'normal'
-                }">
+                class="flex flex-align-center gap-md cursor-pointer"
+                [style.font-weight]="tab.isSelected ? '700' : 'normal'">
                 <span *ngIf="index != null" class="number-circle">{{index + 1}}</span>
                 <i class="{{tab.icon}} primary-color" [style]="showBigTitle ? 'font-size: 19px' : 'font-size: 16px;'"></i> 
                 <div [style]="showBigTitle ? 'font-size: 16px' : ''">{{tab.label}}</div>

--- a/src/app/components/playground/web-app/entity-details/spiderly-panels/panel-header/panel-header.component.ts
+++ b/src/app/components/playground/web-app/entity-details/spiderly-panels/panel-header/panel-header.component.ts
@@ -7,23 +7,7 @@ import { Component, OnInit, Input } from '@angular/core';
   imports: [
     CommonModule,
   ],
-  styles: [`
-    .p-panel-icons-end {
-      font-size: 50px;
-    }
-    .number-circle {
-      border-radius: 50%;
-      width: 33px;
-      height: 33px;
-      padding: 5px;
-
-      background: var(--p-primary-color);
-      border: 1px solid var(--p-primary-color);
-      color: white;
-      text-align: center;
-      display: inline-block;
-    }
-  `],
+  styles: []
 })
 export class PanelHeaderComponent implements OnInit {
   @Input() title: string;

--- a/src/app/components/playground/web-app/entity-details/spiderly-panels/spiderly-card/spiderly-card.component.html
+++ b/src/app/components/playground/web-app/entity-details/spiderly-panels/spiderly-card/spiderly-card.component.html
@@ -1,6 +1,6 @@
 <div class="card responsive-card-padding">
-    <div style="display: flex; align-items: center; margin-bottom: 14px; gap: 12px;">
-        <i  style="font-size: 20px;" class="{{icon}} primary-color"></i>
+    <div class="flex flex-align-center mb-md gap-md">
+        <i class="{{icon}} primary-color" style="font-size: 20px;"></i>
         <h5 style="margin: 0;">{{title}}</h5>
     </div>
     <ng-content></ng-content>

--- a/src/app/components/playground/web-app/entity-details/spiderly-panels/spiderly-panel/spiderly-panel.component.ts
+++ b/src/app/components/playground/web-app/entity-details/spiderly-panels/spiderly-panel/spiderly-panel.component.ts
@@ -9,22 +9,7 @@ import { CommonModule } from '@angular/common';
   selector: 'spiderly-panel',
   templateUrl: './spiderly-panel.component.html',
   styleUrl: './spiderly-panel.component.scss',
-  styles: [`
-    :host {
-      ::ng-deep {
-        .p-panel{
-          overflow: hidden;
-        }
-        .p-panel-icons{
-          display: flex;
-          align-items: center;
-        }
-        .p-panel-header{
-          cursor: pointer;
-        }
-      }
-    }
-  `],
+  styles: [],
   imports: [
     CommonModule,
     PanelModule,

--- a/src/app/components/playground/web-app/table/table.component.ts
+++ b/src/app/components/playground/web-app/table/table.component.ts
@@ -17,22 +17,7 @@ import { PrimengOption } from '../entity-details/entities/primeng-option';
     selector: 'app-table',
     templateUrl: './table.component.html',
     styleUrl: './table.component.scss',
-    styles: [`
-      :host {
-        ::ng-deep {
-          .p-datatable-thead{
-            position: unset !important;
-          }
-          .p-datatable-header{
-            border-radius: 6px 6px 0 0;
-          }
-          .p-datatable {
-            border-radius: var(--p-content-border-radius);
-            border: 1px solid var(--p-surface-700);
-          }
-        }
-      }
-    `],
+    styles: [],
     standalone: true,
     imports: [
         CommonModule,

--- a/src/app/components/section-wrapper/section-wrapper.component.html
+++ b/src/app/components/section-wrapper/section-wrapper.component.html
@@ -1,8 +1,5 @@
-<div 
-[style]="'width: 100%;'"
-[style.background-color]="backgroundColor === 'light' ? 'var(--p-surface-900)' : ''"
->
-    <div class="{{parts === 'one' ? 'container-one' : 'container-two'}}" [style]="{'text-align': 'left'}">
+<div class="w-100" [style.background-color]="backgroundColor === 'light' ? 'var(--p-surface-900)' : ''">
+    <div class="{{parts === 'one' ? 'container-one' : 'container-two'}}" [style.text-align]="textAlign">
         <ng-content></ng-content>
     </div>
 </div>

--- a/src/assets/styles.scss
+++ b/src/assets/styles.scss
@@ -135,3 +135,155 @@ a {
   background-color: var(--p-surface-700);
   border-radius: var(--p-content-border-radius);
 }
+
+// Common styles
+.flex {
+  display: flex;
+}
+
+.flex-column {
+  flex-direction: column;
+}
+
+.flex-align-center {
+  align-items: center;
+}
+
+.flex-justify-center {
+  justify-content: center;
+}
+
+.flex-wrap {
+  flex-wrap: wrap;
+}
+
+.gap-sm {
+  gap: 0.5rem;
+}
+
+.gap-md {
+  gap: 14px;
+}
+
+.gap-lg {
+  gap: 18px;
+}
+
+.mb-sm {
+  margin-bottom: 0.5rem;
+}
+
+.mb-md {
+  margin-bottom: 14px;
+}
+
+.mb-lg {
+  margin-bottom: 20px;
+}
+
+.ml-md {
+  margin-left: 20px;
+}
+
+.mt-sm {
+  margin-top: 1rem;
+}
+
+.ml-sm {
+  margin-left: 1rem;
+}
+
+.ml-4px {
+  margin-left: 4px;
+}
+
+.w-100 {
+  width: 100%;
+}
+
+.h-100 {
+  height: 100%;
+}
+
+.cursor-pointer {
+  cursor: pointer;
+}
+
+.text-align-right {
+  text-align: right;
+}
+
+.text-red {
+  color: red;
+}
+
+// Component specific styles
+.terminal-circle {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.terminal-message {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.p-inputgroup-addon {
+  &.primary {
+    cursor: pointer;
+    background-color: var(--primary-color);
+    border-color: var(--primary-color);
+    
+    i {
+      color: #fff;
+    }
+  }
+}
+
+// Panel styles
+.p-panel {
+  overflow: hidden;
+  
+  &-icons {
+    display: flex;
+    align-items: center;
+  }
+  
+  &-header {
+    cursor: pointer;
+  }
+}
+
+// Table styles
+.p-datatable {
+  border-radius: var(--p-content-border-radius);
+  border: 1px solid var(--p-surface-700);
+  
+  &-thead {
+    position: unset !important;
+  }
+  
+  &-header {
+    border-radius: 6px 6px 0 0;
+  }
+}
+
+// File upload styles
+.p-fileupload-header {
+  padding: 12px 18px !important;
+}
+
+// Number circle styles
+.number-circle {
+  border-radius: 50%;
+  width: 33px;
+  height: 33px;
+  padding: 5px;
+  background: var(--p-primary-color);
+  border: 1px solid var(--p-primary-color);
+  color: white;
+  text-align: center;
+  display: inline-block;
+}


### PR DESCRIPTION
This PR addresses issue #22 by refactoring inline CSS styles into a centralized SCSS file.

Changes made:
- Created a new `styles.scss` file in `src/assets` for centralized styling
- Removed inline styles from multiple components and replaced with utility classes
- Added common utility classes for flex, margins, gaps, etc.
- Added component-specific styles and PrimeNG overrides
- Updated `angular.json` to include the new styles file

Components refactored:
- Panel header
- Spiderly card
- Spiderly autocomplete
- Spiderly multiautocomplete
- Spiderly password
- Class code editor
- Get started
- Required
- Section wrapper
- Spiderly panel
- Table
- Spiderly file

This refactoring improves code maintainability and consistency while reducing style recalculations.