### PR TITLE
docs: AcceptedFileTypes, OnAfterGetMainUIFormDTO, ordered panel template

### DIFF
--- a/content/docs/attributes.mdx
+++ b/content/docs/attributes.mdx
@@ -32,6 +32,27 @@ public class User : BusinessObject<long>
 }
 ```
 
+## AcceptedFileTypes
+
+**Namespace:** `Spiderly.Shared.Attributes.Entity`
+
+### Usage:
+
+Specifies the accepted file types for a blob property. When not applied, the file upload control defaults to accepting images only (`image/*`). Use this attribute alongside `BlobName` for non-image uploads (e.g., PDFs, Excel files).
+
+### Example:
+
+```csharp
+public class Catalog : BusinessObject<int>
+{
+    [BlobName]
+    [S3PublicUrl]
+    [AcceptedFileTypes("application/pdf", ".pdf")]
+    [StringLength(1000, MinimumLength = 1)]
+    public string File { get; set; }
+}
+```
+
 ## CascadeDelete
 
 **Namespace:** `Spiderly.Shared.Attributes.Entity`

--- a/content/docs/backend-customization.mdx
+++ b/content/docs/backend-customization.mdx
@@ -54,6 +54,10 @@ Override virtual methods in `BusinessService` to customize entity operations.
 - `OnBefore{Entity}Delete()` - Execute logic before deleting an entity
 - `OnBefore{Entity}ListDelete()` - Execute logic before bulk deletion
 
+### Read Operation Hooks
+
+- `OnAfterGet{Entity}MainUIFormDTO()` - Enrich the MainUIFormDTO after retrieval (e.g., computed fields, extra queries). Runs inside a database transaction.
+
 ### Save Operation Hooks
 
 - `OnBeforeSave{Entity}AndReturnMainUIFormDTO()` - Validate or modify before save
@@ -84,6 +88,14 @@ namespace YourAppName.Business.Services
         {
             // Custom logic before inserting a product
             product.CreatedByUserId = _authenticationService.GetCurrentUserId();
+        }
+
+        protected override async Task OnAfterGetProductMainUIFormDTO(ProductMainUIFormDTO mainUIFormDTO)
+        {
+            // Enrich the MainUIFormDTO with additional computed data
+            mainUIFormDTO.ReviewCount = await _context.DbSet<Review>()
+                .Where(x => x.ProductId == mainUIFormDTO.ProductDTO.Id)
+                .CountAsync();
         }
 
         protected override async Task OnAfterSaveProductAndReturnMainUIFormDTO(ProductDTO savedDTO, ProductSaveBodyDTO saveBodyDTO)

--- a/content/docs/frontend-customization.mdx
+++ b/content/docs/frontend-customization.mdx
@@ -247,3 +247,29 @@ export class YourEntityNameDataViewComponent implements OnInit {
   }
 }
 ```
+
+## Ordered Many-to-One Panel Customization
+
+### Additional Content Template
+
+You can inject additional content at the bottom of each item in an ordered many-to-one panel using the `additionalContentTemplateFor{Property}For{Entity}` input.
+
+The template receives the form group, index, and whether it's the last item via context:
+
+```html
+<app-product-base-details
+  [additionalContentTemplateForProductItemsForProduct]="extraContent"
+>
+</app-product-base-details>
+
+<ng-template #extraContent let-formGroup let-index="index" let-last="last">
+  <div class="col-12">
+    <p>Item #{{ index + 1 }}</p>
+    <!-- Add custom fields, buttons, or any content here -->
+  </div>
+</ng-template>
+```
+
+<Callout>
+  The template context provides `$implicit` (the formGroup), `formGroup`, `index`, and `last` variables.
+</Callout>


### PR DESCRIPTION
Auto-generated docs update based on 4 new spiderly commits (2026-02-09/10):

- **AcceptedFileTypesAttribute** — new attribute for specifying accepted file types on blob properties (attributes.mdx)
- **OnAfterGet{Entity}MainUIFormDTO** — new lifecycle hook for enriching MainUIFormDTO after retrieval (backend-customization.mdx)
- **additionalContentTemplate for ordered many-to-one panels** — new Input for injecting custom content into ordered panels (frontend-customization.mdx)
- Ordered many-to-one panel fields now default to col-8 (minor, no doc change needed)