### PR TITLE
fix: update GitHub star count from 48 to 50

### DIFF
--- a/src/components/navigation/mobile-navbar.tsx
+++ b/src/components/navigation/mobile-navbar.tsx
@@ -86,7 +86,7 @@ const MobileNavbar = () => {
                 <Star className="size-4 mr-2" />
                 Star on GitHub
                 <span className="ml-2 px-2 py-0.5 bg-muted rounded-full text-xs font-semibold">
-                  48
+                  50
                 </span>
               </Link>
             </div>

--- a/src/components/navigation/navbar.tsx
+++ b/src/components/navigation/navbar.tsx
@@ -79,7 +79,7 @@ const Navbar = () => {
                   <Star className="size-4 mr-2" />
                   Star on GitHub
                   <span className="ml-2 px-2 py-0.5 bg-muted rounded-full text-xs font-semibold">
-                    48
+                    50
                   </span>
                 </Link>
               </Button>


### PR DESCRIPTION
Updated hardcoded star count in navbar and mobile-navbar from 48 to 50 (current actual count).