### PR TITLE
docs: update for Spiderly v19.6.4 — AddSpiderly builder pattern

### DIFF
--- a/content/docs/architecture.mdx
+++ b/content/docs/architecture.mdx
@@ -43,7 +43,8 @@ your-app-name/
 │   │   └── Settings.cs
 │   │
 │   ├── YourApp.Infrastructure/ ← EF Core DbContext, migrations
-│   ├── YourApp.WebAPI/         ← Custom controllers, Program.cs
+│   ├── YourApp.Migrations/    ← Lightweight host for EF Core CLI (avoids DLL lock)
+│   ├── YourApp.WebAPI/         ← Custom controllers, Startup.cs
 │   ├── YourApp.Shared/
 │   │   └── Translations/       ← Translation JSON files (en.json, sr-Latn-RS.json, ...)
 │   └── YourApp.sln

--- a/content/docs/cli-reference.mdx
+++ b/content/docs/cli-reference.mdx
@@ -74,7 +74,7 @@ spiderly add-new-entity --data-view
 
 ### add-migration
 
-Create a new EF Core migration.
+Create a new EF Core migration. The CLI uses the `*.Migrations` project as the startup project (if present), which avoids DLL lock issues when the WebAPI is running. Falls back to `*.WebAPI` if no Migrations project exists.
 
 ```bash
 spiderly add-migration <name>

--- a/content/docs/database-providers.mdx
+++ b/content/docs/database-providers.mdx
@@ -42,7 +42,7 @@ All other packages in the `.csproj` are shared between providers.
 
 ### Startup Configuration
 
-In `Startup.cs`, the Hangfire storage and EF Core provider are configured based on your choice:
+In `Startup.cs`, the Hangfire storage and Spiderly services are configured based on your choice:
 
 **PostgreSQL:**
 
@@ -52,8 +52,12 @@ services.AddHangfire(config =>
         Spiderly.Shared.SettingsProvider.Current.ConnectionString)
 );
 
-services.SpiderlyConfigureServices<YourAppApplicationDbContext>(
-    dbProvider: DbProviderCodes.PostgreSQL);
+services.AddSpiderly<YourAppApplicationDbContext>(spiderly =>
+{
+    spiderly.UsePostgreSQL();
+    spiderly.AddAuthentication();
+    // ... other features
+});
 ```
 
 **SQL Server:**
@@ -64,8 +68,12 @@ services.AddHangfire(config =>
         Spiderly.Shared.SettingsProvider.Current.ConnectionString)
 );
 
-services.SpiderlyConfigureServices<YourAppApplicationDbContext>(
-    dbProvider: DbProviderCodes.SQLServer);
+services.AddSpiderly<YourAppApplicationDbContext>(spiderly =>
+{
+    spiderly.UseSQLServer();
+    spiderly.AddAuthentication();
+    // ... other features
+});
 ```
 
 ### VS Code Extensions
@@ -133,7 +141,7 @@ If you need to switch providers after project creation, follow these steps:
 
 1. **Swap NuGet packages** in `Backend/YourApp.WebAPI/YourApp.WebAPI.csproj` — replace the EF Core and Hangfire packages (see [comparison table](#comparison-table) above).
 2. **Update Hangfire storage** in `Startup.cs` — change `UseHangfirePostgreSqlStorage` to `UseSqlServerStorage` (or vice versa).
-3. **Change `DbProviderCodes`** in the `SpiderlyConfigureServices` call in `Startup.cs`.
+3. **Change the provider call** in the `AddSpiderly` builder in `Startup.cs` — switch `UsePostgreSQL()` to `UseSQLServer()` (or vice versa).
 4. **Update the connection string** in user secrets (`dotnet user-secrets set`).
 5. **Delete existing migrations** from `Backend/YourApp.Infrastructure/Migrations/` and create a new initial migration with `spiderly add-migration Init`.
 

--- a/content/docs/file-storage.mdx
+++ b/content/docs/file-storage.mdx
@@ -119,14 +119,15 @@ public class Brand : BusinessObject<int>
 }
 ```
 
-**DI registration (Program.cs or CompositionRoot):**
+**DI registration — use `AddFileStorage` and `AddAzureBlobStorage` in the Spiderly builder:**
 
 ```csharp
-BlobContainerClient blobContainerClient = new BlobContainerClient(
-    settings.BlobStorageConnectionString,
-    settings.BlobStorageContainerName
-);
-services.AddSingleton<IFileManager>(new BlobStorageService(blobContainerClient));
+services.AddSpiderly<YourAppApplicationDbContext>(spiderly =>
+{
+    // ...
+    spiderly.AddFileStorage<BlobStorageService>();
+    spiderly.AddAzureBlobStorage(); // registers BlobServiceClient + BlobContainerClient
+});
 ```
 
 ### S3 Private
@@ -143,12 +144,17 @@ services.AddSingleton<IFileManager>(new BlobStorageService(blobContainerClient))
 }
 ```
 
-**DI registration:**
+**DI registration — use `AddFileStorage` in the Spiderly builder:**
 
 ```csharp
-services.AddSingleton<IAmazonS3>(s3Client);
-services.AddSingleton<IFileManager>(sp => new S3StorageService(sp.GetRequiredService<IAmazonS3>()));
+services.AddSpiderly<YourAppApplicationDbContext>(spiderly =>
+{
+    // ...
+    spiderly.AddFileStorage<S3StorageService>();
+});
 ```
+
+You still need to register `IAmazonS3` yourself (e.g., `services.AddSingleton<IAmazonS3>(s3Client)`).
 
 ### S3 Public (Cloudflare R2, CloudFront, etc.)
 
@@ -194,12 +200,14 @@ Cloudinary is auto-configured — no manual DI registration needed. The generate
 
 No configuration needed. Files are stored in `{CurrentDirectory}/FileStorage`.
 
-**DI registration:**
+**DI registration — use `AddFileStorage` in the Spiderly builder:**
 
 ```csharp
-services.AddSingleton<IFileManager>(new DiskStorageService());
-// or with a custom path:
-services.AddSingleton<IFileManager>(new DiskStorageService("/path/to/storage"));
+services.AddSpiderly<YourAppApplicationDbContext>(spiderly =>
+{
+    // ...
+    spiderly.AddFileStorage<DiskStorageService>();
+});
 ```
 
 ## Generated Upload Pipeline

--- a/content/docs/set-up-emailing.mdx
+++ b/content/docs/set-up-emailing.mdx
@@ -39,20 +39,22 @@ Add your Brevo API key to the `Spiderly.Shared` section of `appsettings.json` (o
 }
 ```
 
-### 2. Register the Brevo HttpClient
+### 2. Register Brevo in the Spiderly builder
 
-In your `Startup.ConfigureServices` (or `Program.cs`), call:
-
-```csharp
-services.SpiderlyAddBrevoEmailingService();
-```
-
-### 3. Register `BrevoEmailingService` in DI
-
-Wire up `IEmailingService` to the Brevo implementation:
+In your `Startup.ConfigureServices`, use `AddBrevoEmailing()` inside the `AddSpiderly` builder:
 
 ```csharp
-registry.Register<IEmailingService, Spiderly.Shared.Emailing.BrevoEmailingService>();
+services.AddSpiderly<YourAppApplicationDbContext>(spiderly =>
+{
+    spiderly.UsePostgreSQL(); // or UseSQLServer()
+    spiderly.AddAuthentication();
+    spiderly.AddBrevoEmailing(); // registers BrevoEmailingService + HttpClient
+    // ... other features
+});
 ```
 
-That's it — all emails (verification, exception alerts, background jobs) will now be sent through the Brevo API.
+That's it — `AddBrevoEmailing()` registers both the `BrevoEmailingService` as `IEmailingService` and the named `"Brevo"` HttpClient. All emails (verification, exception alerts, background jobs) will now be sent through the Brevo API.
+
+<Callout>
+  For a custom emailing implementation, use `spiderly.AddEmailing<YourEmailingService>()` instead, where `YourEmailingService` implements `IEmailingService`.
+</Callout>


### PR DESCRIPTION
Updates documentation to reflect Spiderly v19.6.4 changes:

## What changed in Spiderly
- **`SpiderlyConfigureServices` replaced with `AddSpiderly` modular builder pattern** — opt-in feature registration instead of all-in-one
- **LightInject removed** — standard Microsoft DI throughout (`CompositionRoot` → `AppServiceExtensions`)
- **`SpiderlyConfigure()` removed** — developers compose middleware explicitly
- **New `*.Migrations` project** — lightweight EF Core CLI host, avoids DLL lock when WebAPI is running
- **`SpiderlyAddBrevoEmailingService()` → `AddBrevoEmailing()`** integrated into builder

## Docs updated
- **architecture.mdx** — added Migrations project to structure, updated WebAPI description
- **database-providers.mdx** — replaced `SpiderlyConfigureServices` examples with `AddSpiderly` builder, updated switching instructions
- **set-up-emailing.mdx** — replaced old Brevo 3-step setup with single `AddBrevoEmailing()` builder call
- **file-storage.mdx** — updated all DI registration examples to use `AddFileStorage<T>()` builder
- **cli-reference.mdx** — noted Migrations project preference for migration commands